### PR TITLE
searches use scrolling for much win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.1.3] - 2015-06-27
+## [0.1.1] - 2015-06-29
+### Changed
+* Searches now scroll through the index for more speed and less memory usage
+* Index queries request the minimum amount of data
+
 ### Fixed
 * Don't try to generate geohash for null geometry
 
-## [0.1.2] - 2015-06-27
-### Changed
-* Index queries request the minimum amount of data
-
-## [0.1.1] - 2015-06-26
 ### Removed
 * Got rid of the index refresh in serviceRegister as its not needed there in every case. Moved it to the tests.
 
@@ -55,8 +54,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Support for insert, select, counting, and removing data
 * 12 tests passing 
 
-[0.1.3]: https://github.com/Esri/koop-pgcache/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/Esri/koop-pgcache/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Esri/koop-pgcache/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Esri/koop-pgcache/compare/v0.0.7...v0.1.0
 [0.0.7]: https://github.com/Esri/koop-pgcache/compare/v0.0.6...v0.0.7

--- a/index.js
+++ b/index.js
@@ -639,9 +639,9 @@ module.exports = {
     var self = this
     params.search_type = 'scan'
     params.scroll = '30s'
-    if (!params.size) params.size = 40
+    params.size = 200
     this.client.search(params, function scroll (err, res) {
-      if (err) return callback(err)
+      if (err) console.trace(err)
       res.hits.hits.forEach(function (hit) {
         try {
           features.push(JSON.parse(hit.fields.feature))

--- a/index.js
+++ b/index.js
@@ -646,7 +646,6 @@ module.exports = {
     this.client.search(params, function scroll (err, res) {
       if (err) console.trace(err)
       count += res.hits.hits.length
-      console.log(count)
       res.hits.hits.forEach(function (hit) {
         try {
           features.push(JSON.parse(hit.fields.feature))

--- a/index.js
+++ b/index.js
@@ -636,17 +636,22 @@ module.exports = {
   _scrollSearch: function(params, callback) {
     var features = []
     var parseFailures = 0
+    var count = 0
     var self = this
     params.search_type = 'scan'
     params.scroll = '30s'
-    params.size = 200
+    // the actual number sent = shards * params.size = 10
+    // https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html
+    params.size = 40
     this.client.search(params, function scroll (err, res) {
       if (err) console.trace(err)
+      count += res.hits.hits.length
+      console.log(count)
       res.hits.hits.forEach(function (hit) {
         try {
           features.push(JSON.parse(hit.fields.feature))
         } catch (e) {
-          this.log.error(e, hit)
+          self.log.error(e, hit)
           parseFailures++
         }
       })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop-escache",
-  "version": "0.1.3",
+  "version": "0.1.1",
   "description": "An Elastic Search cache for koop",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Instead of requesting everything at once, this pages and uses a search type of scan to avoid any scoring

Benefits:
- Process no longer has to hold entire searches in memory at once
- much faster for large requests

See: https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html
