### PR TITLE
add name, type, version to exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,13 @@ var ngeohash = require('ngeohash')
 var centroid = require('turf-centroid')
 var async = require('async')
 var merc = require('sphericalmercator')
+var pkg = require('./package')
 
 module.exports = {
-  type: 'elasticsearch',
+  type: 'cache',
+  name: 'elasticsearch',
+  version: pkg.version,
+
   indexName: 'koop',
   limit: 2000,
 


### PR DESCRIPTION
Same as https://github.com/koopjs/koop-pgcache/pull/28

Noticed there's already a `type` property being exported here (`elasticsearch`).

My reasoning for making `type: 'cache'` is that corresponds to `type: 'plugin'`, as in https://github.com/koopjs/koop-tile-plugin/blob/master/index.js#L6-L10. Eventually all providers would export `type` of provider, all caches `type` of cache, all plugins `type` of plugin, so we could infer what to do with them more easily and display information from them through the API more automagically.

:tophat: :sparkles: :rabbit2: 
